### PR TITLE
Honor configured font family

### DIFF
--- a/cli/src/code_config.rs
+++ b/cli/src/code_config.rs
@@ -9,7 +9,7 @@ pub fn create_code_config(cli: &CLI, code_config: CodeConfig) -> anyhow::Result<
     parsed_code_config.font_family = cli
         .code_font_family
         .clone()
-        .unwrap_or(parsed_code_config.font_family);
+        .unwrap_or(code_config.font_family);
 
     Ok(parsed_code_config)
 }


### PR DESCRIPTION
If command-line `--code-font-family` is not provided, defer to the font family in config.json

When populating `parsed_code_config.font_family`, `create_code_config` seems to be deferring to what's already populated in `parsed_code_config.font_family` when `cli.code_font_family` isn't provided, rather than deferring to the provided `code_config`.